### PR TITLE
Passwords that have XML characters in them...

### DIFF
--- a/lib/omniauth/strategies/crowd/crowd_validator.rb
+++ b/lib/omniauth/strategies/crowd/crowd_validator.rb
@@ -32,7 +32,7 @@ module OmniAuth
             "email" => doc.xpath("//user/email/text()").to_s
           }
         end
-        AUTHENTICATION_REQUEST_BODY = "<password><value>%s</value></password>"
+        AUTHENTICATION_REQUEST_BODY = "<password><value><![CDATA[%s]]></value></password>"
         def is_user_authorized?
           http = Net::HTTP.new(@uri.host, @uri.port)
           http.use_ssl = @uri.port == 443 || @uri.instance_of?(URI::HTTPS)


### PR DESCRIPTION
In using your omniauth_crowd gem, I noticed that passwords that have XML entities in them (e.g. &, >, etc) aren't properly escaped in the CrowdValidator is_user_authorized? method.

Wrapping the password in a <![CDATA[  ]]> block solves the problem.
