### PR TITLE
Passes tests using omniauth 1.1.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
     diff-lcs (1.1.3)
     hashie (1.2.0)
     nokogiri (1.5.2)
-    omniauth (1.0.3)
+    omniauth (1.1.1)
       hashie (~> 1.2)
       rack
     rack (1.4.1)

--- a/lib/omniauth/strategies/crowd.rb
+++ b/lib/omniauth/strategies/crowd.rb
@@ -32,7 +32,7 @@ module OmniAuth
     
       def callback_phase 
         creds = session.delete 'omniauth.crowd'
-        return fail!(:no_credentials, 'No Credentials') unless creds
+        return fail!(:no_credentials, nil) unless creds
         validator = CrowdValidator.new(@configuration, creds['username'], creds['password'])
         @user_info = validator.user_info
         


### PR DESCRIPTION
...ception class or nil

I'm working on troubleshooting an issue and wanted to add logging. To do so, I needed to update omniauth_crowd to use a newer version of omniauth. when I did so, it failed a test. The newer version of omniauth expects an Exception class. I made the test pass by changing the exception parameter to nil from the string. 

I'll leave it up to you if you want to implement a proper exception. Just needed the test to pass for now.
