### PR TITLE
escape credentials sent to Crowd

### DIFF
--- a/lib/omniauth/strategies/crowd/crowd_validator.rb
+++ b/lib/omniauth/strategies/crowd/crowd_validator.rb
@@ -1,6 +1,7 @@
 require 'nokogiri'
 require 'net/http'
 require 'net/https'
+require 'rexml/text'
 
 module OmniAuth
   module Strategies
@@ -103,14 +104,14 @@ module OmniAuth
         def make_authentication_request_body(password)
           request_body = Nokogiri::XML(AUTHENTICATION_REQUEST_BODY)
           password_value = request_body.at_css "value"
-          password_value.content = password
+          password_value.content = REXML::Text.normalize(password)
           return request_body.root.to_s # return the body without the xml header
         end
 
         def make_session_request_body(username,password)
           request_body = Nokogiri::XML(SESSION_REQUEST_BODY)
-          request_body.at_css("username").content = username
-          request_body.at_css("password").content = password
+          request_body.at_css("username").content = REXML::Text.normalize(username)
+          request_body.at_css("password").content = REXML::Text.normalize(password)
           return request_body.root.to_s
         end
       end

--- a/spec/omniauth/strategies/crowd_spec.rb
+++ b/spec/omniauth/strategies/crowd_spec.rb
@@ -1,4 +1,5 @@
 require File.dirname(__FILE__) + '/../../spec_helper'
+require 'nokogiri'
 
 describe OmniAuth::Strategies::Crowd, :type=>:strategy do
   include OmniAuth::Test::StrategyTestCase
@@ -68,6 +69,18 @@ describe OmniAuth::Strategies::Crowd, :type=>:strategy do
       end
     end
 
+    context "when using authentication endpoint with special characters" do
+      before do
+        stub_request(:post, "https://bogus_app:bogus_app_password@crowd.example.org/rest/usermanagement/latest/authentication?username=foo")
+        get '/auth/crowd/callback', nil, 'rack.session'=>{'omniauth.crowd'=> {"username"=>"foo", "password"=>"bar&<xml>"}}
+      end
+
+      it 'should escape special characters' do
+        WebMock.should have_requested(:post, 'https://bogus_app:bogus_app_password@crowd.example.org/rest/usermanagement/latest/authentication?username=foo').
+          with { |req| Nokogiri::XML(req.body).at_css("value").content == 'bar&amp;&lt;xml&gt;' }
+      end
+    end
+
     context "when using session endpoint" do
       before do
         @use_sessions = true
@@ -100,6 +113,23 @@ describe OmniAuth::Strategies::Crowd, :type=>:strategy do
         auth = last_request.env['omniauth.auth']['user_info']['sso_token'].should == 'rtk8eMvqq00EiGn5iJCMZQ00'
         auth = last_request.env['omniauth.auth']['user_info']['groups'].sort.should == ["Developers", "jira-users"].sort
       end
+    end
+  end
+
+  context "when using session endpoint with special characters" do
+    before do
+      @use_sessions = true
+      stub_request(:post, "https://bogus_app:bogus_app_password@crowd.example.org/rest/usermanagement/latest/authentication?username=foo%26%3Cxml%3E").
+      to_return(:body => File.read(File.join(File.dirname(__FILE__), '..', '..', 'fixtures', 'success.xml')))
+      stub_request(:post, "https://bogus_app:bogus_app_password@crowd.example.org/rest/usermanagement/latest/session").
+      to_return(:status => 201, :body => File.read(File.join(File.dirname(__FILE__), '..', '..', 'fixtures', 'session.xml')))
+      stub_request(:get, "https://bogus_app:bogus_app_password@crowd.example.org/rest/usermanagement/latest/user/group/direct?username=foo%26%3Cxml%3E").
+      to_return(:body => File.read(File.join(File.dirname(__FILE__), '..', '..', 'fixtures', 'groups.xml')))
+      get '/auth/crowd/callback', nil, 'rack.session'=>{'omniauth.crowd'=> {"username"=>"foo&<xml>", "password"=>"bar&<xml>"}}
+    end
+    it 'should escape special characters' do
+      WebMock.should have_requested(:post, 'https://bogus_app:bogus_app_password@crowd.example.org/rest/usermanagement/latest/session').
+        with { |req| Nokogiri::XML(req.body).at_css("username").content == 'foo&amp;&lt;xml&gt;' and Nokogiri::XML(req.body).at_css("password").content == 'bar&amp;&lt;xml&gt;' }
     end
   end
 


### PR DESCRIPTION
Hi,

I recently ran into a problem authenticating with an app that uses the "omniauth_crowd" strategy. I eventually traced the problem down to my password containing a chevron ("<"). My teammate and I found the problem in the source code and I wrote up a proposed fix with some tests. Please let me know if you have any questions.

Thanks
Sam Placette
