### PR TITLE
Removed invalid content type that was reintroduced, breaking group requests

### DIFF
--- a/lib/omniauth/strategies/crowd/crowd_validator.rb
+++ b/lib/omniauth/strategies/crowd/crowd_validator.rb
@@ -84,7 +84,6 @@ BODY
             req = http_method.new(uri.query.nil? ? uri.path : "#{uri.path}?#{uri.query}")
             req.body = body if body
             req.basic_auth @configuration.crowd_application_name, @configuration.crowd_password
-            req.add_field 'Content-Type', 'text/xml'
             http.request(req)
           end
         end

--- a/spec/omniauth/strategies/crowd_spec.rb
+++ b/spec/omniauth/strategies/crowd_spec.rb
@@ -97,8 +97,13 @@ BODY
       before do
         stub_request(:post, "https://bogus_app:bogus_app_password@crowd.example.org/rest/usermanagement/latest/authentication?username=foo").
         to_return(:body => File.read(File.join(File.dirname(__FILE__), '..', '..', 'fixtures', 'success.xml')))
+
         stub_request(:get, "https://bogus_app:bogus_app_password@crowd.example.org/rest/usermanagement/latest/user/group/direct?username=foo").
-        to_return(:body => File.read(File.join(File.dirname(__FILE__), '..', '..', 'fixtures', 'groups.xml')))
+            to_return(:body => File.read(File.join(File.dirname(__FILE__), '..', '..', 'fixtures', 'groups.xml')))
+
+        #Adding this to prevent Content-Type text/xml from being added back in the future
+        stub_request(:get, "https://bogus_app:bogus_app_password@crowd.example.org/rest/usermanagement/latest/user/group/direct?username=foo").with(:headers => {"Content-Type" => "text/xml"}).
+            to_return(:status => [415, "Unsupported Media Type"])
         get '/auth/crowd/callback', nil, 'rack.session'=>{'omniauth.crowd'=> {"username"=>"foo", "password"=>"ba"}}
       end
       it 'should call through to the master app' do
@@ -109,10 +114,11 @@ BODY
         auth.should be_kind_of(Hash)
       end
       it 'should have good data' do
-        auth = last_request.env['omniauth.auth']['provider'].should == :crowd
-        auth = last_request.env['omniauth.auth']['uid'].should == 'foo'
-        auth = last_request.env['omniauth.auth']['user_info'].should be_kind_of(Hash)
-        auth = last_request.env['omniauth.auth']['user_info']['groups'].sort.should == ["Developers", "jira-users"].sort
+        auth = last_request.env['omniauth.auth']
+        auth['provider'].should == :crowd
+        auth['uid'].should == 'foo'
+        auth['user_info'].should be_kind_of(Hash)
+        auth['user_info']['groups'].sort.should == ["Developers", "jira-users"].sort
       end
     end
 
@@ -142,11 +148,12 @@ BODY
       end
 
       it 'should have good data' do
-        auth = last_request.env['omniauth.auth']['provider'].should == :crowd
-        auth = last_request.env['omniauth.auth']['uid'].should == 'foo'
-        auth = last_request.env['omniauth.auth']['user_info'].should be_kind_of(Hash)
-        auth = last_request.env['omniauth.auth']['user_info']['sso_token'].should == 'rtk8eMvqq00EiGn5iJCMZQ00'
-        auth = last_request.env['omniauth.auth']['user_info']['groups'].sort.should == ["Developers", "jira-users"].sort
+        auth = last_request.env['omniauth.auth']
+        auth['provider'].should == :crowd
+        auth['uid'].should == 'foo'
+        auth['user_info'].should be_kind_of(Hash)
+        auth['user_info']['sso_token'].should == 'rtk8eMvqq00EiGn5iJCMZQ00'
+        auth['user_info']['groups'].sort.should == ["Developers", "jira-users"].sort
       end
     end
   end


### PR DESCRIPTION
This broke between 2.1.1 and 2.1.2 with commit bc39b176754b762f0af8c68462a33c62e108d1e4

I've also made an addition to the crowd spec that responds in the same way Crowd will respond to this content type header, and made corrections to the 'should have good data' steps.
