### PR TITLE
set the default content type to application/xml

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniauth_crowd (2.2.1)
+    omniauth_crowd (2.2.2)
       nokogiri (>= 1.4.4)
       omniauth (~> 1.0)
 
@@ -13,7 +13,7 @@ GEM
       safe_yaml (~> 0.9.0)
     diff-lcs (1.1.3)
     hashie (2.0.5)
-    mini_portile (0.5.1)
+    mini_portile (0.5.2)
     nokogiri (1.6.0)
       mini_portile (~> 0.5.0)
     omniauth (1.1.4)

--- a/lib/omniauth/strategies/crowd/configuration.rb
+++ b/lib/omniauth/strategies/crowd/configuration.rb
@@ -7,6 +7,8 @@ module OmniAuth
         DEFAULT_SESSION_URL = "%s/rest/usermanagement/latest/session"
         DEFAULT_AUTHENTICATION_URL = "%s/rest/usermanagement/latest/authentication"
         DEFAULT_USER_GROUP_URL = "%s/rest/usermanagement/latest/user/group/direct"
+        DEFAULT_CONTENT_TYPE = 'application/xml'
+
         attr_reader :crowd_application_name, :crowd_password, :disable_ssl_verification, :include_users_groups, :use_sessions, :session_url, :content_type
 
         alias :"disable_ssl_verification?" :disable_ssl_verification
@@ -53,7 +55,7 @@ module OmniAuth
           @crowd_application_name = options[:application_name]
           @crowd_password         = options[:application_password]
           @use_sessions           = options[:use_sessions]
-          @content_type           = options[:content_type]
+          @content_type           = options[:content_type] || DEFAULT_CONTENT_TYPE
 
           unless options.include?(:crowd_server_url) || options.include?(:crowd_authentication_url)
             raise ArgumentError.new("Either :crowd_server_url or :crowd_authentication_url MUST be provided")

--- a/lib/omniauth_crowd/version.rb
+++ b/lib/omniauth_crowd/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Crowd
-    VERSION = "2.2.1"
+    VERSION = "2.2.2"
   end
 end


### PR DESCRIPTION
So when I removed content type I made a huge mistake! In our code we had a monkey patch for something @combhua added, so when I tested it on an application it worked fine because I didn't actually test my changes! I found that using no content type gives 415, and that using text/xml gives strange errors. I've made an additional change with the configurable content type to set the default to application/xml, which I can see is working. If that doesn't work for a majority of people the default can be changed, but for now I've verified it works with my crowd server / application.
