### PR TITLE
Symbolization of passed options keys

### DIFF
--- a/lib/omniauth/strategies/crowd.rb
+++ b/lib/omniauth/strategies/crowd.rb
@@ -8,6 +8,7 @@ module OmniAuth
       autoload :Configuration, 'omniauth/strategies/crowd/configuration'
       autoload :CrowdValidator, 'omniauth/strategies/crowd/crowd_validator'
       def initialize(app, options = {}, &block)
+        options.symbolize_keys!()
         super(app, {:name=> :crowd}.merge(options), &block)
         @configuration = OmniAuth::Strategies::Crowd::Configuration.new(options)
       end


### PR DESCRIPTION
Forcing key symbolization for passed options makes possible to configure the gem changing only the gitlab.yml file using standard formatting:

provider:
- { name: 'crowd', args: { crowd_server_url: 'http://<CROWD_SERVER_IP:PORT>/crowd', application_name: "<APP_NAME>", application_password: "<APP_PASSWORD>", title: '<YOUR_DOMAIN_NAME> Crowd' } }

Also supports the older configurations modes.

Tested with Gitlab 6.6.0 and omiauth_crowd 2.2.2.
