### PR TITLE
Add new session & SSO features

### DIFF
--- a/lib/omniauth/strategies/crowd.rb
+++ b/lib/omniauth/strategies/crowd.rb
@@ -18,7 +18,13 @@ module OmniAuth
 
       def request_phase
         if env['REQUEST_METHOD'] == 'GET'
-          get_credentials
+
+          if @configuration.use_sso? && request.cookies[@configuration.session_cookie]
+            redirect callback_url
+          else            
+            get_credentials
+          end
+
         elsif (env['REQUEST_METHOD'] == 'POST') && (not request.params['username'])
           get_credentials
         else
@@ -27,17 +33,52 @@ module OmniAuth
         end
       end
 
+      def get_client_ip
+        env['HTTP_X_FORWARDED_FOR'] ? env['HTTP_X_FORWARDED_FOR'] : env['REMOTE_ADDRESS']
+      end
+
+      def get_sso_tokens
+        env['HTTP_COOKIE'].split(';').select { |val| 
+          val.strip.start_with?(@configuration.session_cookie)
+        }.map { |val| 
+          val.strip.split('=').last
+        }            
+      end
+
       def get_credentials
+
+        configuration = @configuration
+
         OmniAuth::Form.build(:title => (options[:title] || "Crowd Authentication")) do
           text_field 'Login', 'username'
           password_field 'Password', 'password'
-        end.to_response
-      end
 
+          if configuration.use_sso? && configuration.sso_url
+            fieldset 'SSO' do
+              html "<a href=\"#{configuration.sso_url}/users/auth/crowd/callback\">" + (configuration.sso_url_image ? "<img src=\"#{configuration.sso_url_image}\" />" : '') + "</a>"
+            end
+          end
+
+        end.to_response
+
+      end
+      
       def callback_phase
+
         creds = session.delete 'omniauth.crowd'
-        return fail!(:no_credentials) unless creds
-        validator = CrowdValidator.new(@configuration, creds['username'], creds['password'])
+        username = creds.nil? ? nil : creds['username']
+        password = creds.nil? ? nil : creds['password']
+
+        unless creds
+          if @configuration.use_sso? && request.cookies[@configuration.session_cookie]
+            validator = CrowdValidator.new(@configuration, username, password, tokens: get_sso_tokens, client_ip: get_client_ip)
+          else
+            return fail!(:no_credentials)            
+          end
+        else
+          validator = CrowdValidator.new(@configuration, username, password, client_ip: get_client_ip)
+        end
+
         @user_info = validator.user_info
 
         return fail!(:invalid_credentials) if @user_info.nil? || @user_info.empty?

--- a/lib/omniauth/strategies/crowd.rb
+++ b/lib/omniauth/strategies/crowd.rb
@@ -71,12 +71,12 @@ module OmniAuth
 
         unless creds
           if @configuration.use_sso? && request.cookies[@configuration.session_cookie]
-            validator = CrowdValidator.new(@configuration, username, password, tokens: get_sso_tokens, client_ip: get_client_ip)
+            validator = CrowdValidator.new(@configuration, username, password, get_client_ip, get_sso_tokens)
           else
-            return fail!(:no_credentials)            
+            return fail!(:no_credentials)
           end
         else
-          validator = CrowdValidator.new(@configuration, username, password, client_ip: get_client_ip)
+          validator = CrowdValidator.new(@configuration, username, password, get_client_ip, nil)
         end
 
         @user_info = validator.user_info

--- a/lib/omniauth/strategies/crowd/crowd_validator.rb
+++ b/lib/omniauth/strategies/crowd/crowd_validator.rb
@@ -7,8 +7,8 @@ module OmniAuth
     class Crowd
       class CrowdValidator
         AUTHENTICATION_REQUEST_BODY = "<password><value>%s</value></password>"
-        def initialize(configuration, username, password, tokens: nil, client_ip: nil)
-          @configuration, @username, @password, @tokens, @client_ip = configuration, username, password, tokens, client_ip
+        def initialize(configuration, username, password, client_ip, tokens)
+          @configuration, @username, @password, @client_ip, @tokens = configuration, username, password, client_ip, tokens
           @authentiction_uri = URI.parse(@configuration.authentication_url(@username))
           @session_uri       = URI.parse(@configuration.session_url) if @configuration.use_sessions
         end
@@ -114,7 +114,7 @@ module OmniAuth
 
         def make_authorization_request
 
-          if @configuration.use_sessions? && @tokens
+          if @configuration.use_sessions? && @tokens.kind_of?(Array)
             make_session_retrieval_request
           else 
             make_request(@authentiction_uri, make_authentication_request_body(@password))

--- a/lib/omniauth/strategies/crowd/crowd_validator.rb
+++ b/lib/omniauth/strategies/crowd/crowd_validator.rb
@@ -6,22 +6,16 @@ module OmniAuth
   module Strategies
     class Crowd
       class CrowdValidator
-        SESSION_REQUEST_BODY = <<-BODY.strip
-<authentication-context>
-  <username>%s</username>
-  <password>%s</password>
-</authentication-context>
-BODY
         AUTHENTICATION_REQUEST_BODY = "<password><value>%s</value></password>"
-        def initialize(configuration, username, password)
-          @configuration, @username, @password = configuration, username, password
+        def initialize(configuration, username, password, tokens: nil, client_ip: nil)
+          @configuration, @username, @password, @tokens, @client_ip = configuration, username, password, tokens, client_ip
           @authentiction_uri = URI.parse(@configuration.authentication_url(@username))
           @session_uri       = URI.parse(@configuration.session_url) if @configuration.use_sessions
-          @user_group_uri    = @configuration.include_users_groups? ? URI.parse(@configuration.user_group_url(@username)) : nil
         end
 
         def user_info
           user_info_hash = retrieve_user_info!
+
           if user_info_hash && @configuration.include_users_groups?
             user_info_hash = add_user_groups!(user_info_hash)
           else
@@ -29,27 +23,36 @@ BODY
           end
 
           if user_info_hash && @configuration.use_sessions?
-            user_info_hash = add_session!(user_info_hash)
+            user_info_hash = set_session!(user_info_hash)
           end
 
           user_info_hash
         end
 
         private
-        def add_session!(user_info_hash)
-          response = make_session_request
+        def set_session!(user_info_hash)
+
+          response = nil
+
+          if user_info_hash["sso_token"]
+            response = make_session_request(token: user_info_hash["sso_token"])
+          else
+            response = make_session_request
+          end
+
           if response.kind_of?(Net::HTTPSuccess) && response.body
             doc = Nokogiri::XML(response.body)
             user_info_hash["sso_token"] = doc.xpath('//token/text()').to_s
           else
-            OmniAuth.logger.send(:warn, "(crowd) [add_session!] response code: #{response.code.to_s}")
-            OmniAuth.logger.send(:warn, "(crowd) [add_session!] response body: #{response.body}")
+            OmniAuth.logger.send(:warn, "(crowd) [set_session!] response code: #{response.code.to_s}")
+            OmniAuth.logger.send(:warn, "(crowd) [set_session!] response body: #{response.body}")
           end
+
           user_info_hash
         end
 
         def add_user_groups!(user_info_hash)
-          response = make_user_group_request
+          response = make_user_group_request(user_info_hash['user'])
           unless response.code.to_i != 200 || response.body.nil? || response.body == ''
             doc = Nokogiri::XML(response.body)
             user_info_hash["groups"] = doc.xpath("//groups/group/@name").map(&:to_s)
@@ -59,18 +62,32 @@ BODY
 
         def retrieve_user_info!
           response = make_authorization_request
-          unless response.code.to_i != 200 || response.body.nil? || response.body == ''
-            doc = Nokogiri::XML(response.body)
-            {
-              "user" => doc.xpath("//user/@name").to_s,
-              "name" => doc.xpath("//user/display-name/text()").to_s,
-              "first_name" => doc.xpath("//user/first-name/text()").to_s,
-              "last_name" => doc.xpath("//user/last-name/text()").to_s,
-              "email" => doc.xpath("//user/email/text()").to_s
-            }
+
+          unless response === nil
+            unless response.code.to_i != 200 || response.body.nil? || response.body == ''
+
+              doc = Nokogiri::XML(response.body)
+              result = {
+                "user" => doc.xpath("//user/@name").to_s,
+                "name" => doc.xpath("//user/display-name/text()").to_s,
+                "first_name" => doc.xpath("//user/first-name/text()").to_s,
+                "last_name" => doc.xpath("//user/last-name/text()").to_s,
+                "email" => doc.xpath("//user/email/text()").to_s
+              }
+
+              if doc.at_xpath("//token")
+                result["sso_token"] = doc.xpath("//token/text()").to_s
+              end
+
+              result
+              
+            else
+              OmniAuth.logger.send(:warn, "(crowd) [retrieve_user_info!] response code: #{response.code.to_s}")
+              OmniAuth.logger.send(:warn, "(crowd) [retrieve_user_info!] response body: #{response.body}")
+              nil
+            end
           else
-            OmniAuth.logger.send(:warn, "(crowd) [retrieve_user_info!] response code: #{response.code.to_s}")
-            OmniAuth.logger.send(:warn, "(crowd) [retrieve_user_info!] response body: #{response.body}")
+            OmniAuth.logger.send(:warn, "(crowd) [retrieve_user_info!] None of the session tokens were valid")
             nil
           end
         end
@@ -91,17 +108,57 @@ BODY
           end
         end
 
-        def make_user_group_request
-          make_request(@user_group_uri)
+        def make_user_group_request(username)
+          make_request(URI.parse(@configuration.user_group_url(username)))
         end
 
         def make_authorization_request
-          make_request(@authentiction_uri, make_authentication_request_body(@password))
+
+          if @configuration.use_sessions? && @tokens
+            make_session_retrieval_request
+          else 
+            make_request(@authentiction_uri, make_authentication_request_body(@password))
+          end
         end
 
-        def make_session_request
-          make_request(@session_uri, make_session_request_body(@username, @password))
-        end
+        def make_session_request(token: nil)
+
+          root = url = validation_factor = nil
+          doc = Nokogiri::XML::Document.new
+
+          if token === nil
+
+            url = @session_uri
+            root = doc.create_element('authentication-context')
+
+            doc.root = root
+            root.add_child(doc.create_element('username', @username))
+            root.add_child(doc.create_element('password', @password))
+
+          else
+            url = URI.parse(@session_uri.to_s() + "/#{token}")
+          end
+
+          if @configuration.use_sessions? || @client_ip
+
+            if root === nil
+              root = doc.create_element('validation-factors')
+              doc.root = root
+            else
+              root.add_child(doc.create_element('validation-factors'))
+            end
+
+            validation_factor = doc.create_element('validation-factor')
+            validation_factor.add_child(doc.create_element('name', 'remote_address'))
+            validation_factor.add_child(doc.create_element('value', @client_ip))
+            
+            doc.xpath('//validation-factors').first.add_child(validation_factor)
+            
+          end
+          
+          make_request(url, doc.to_s)
+          
+        end        
 
         # create the body using Nokogiri so proper encoding of passwords can be ensured
         def make_authentication_request_body(password)
@@ -111,11 +168,17 @@ BODY
           return request_body.root.to_s # return the body without the xml header
         end
 
-        def make_session_request_body(username,password)
-          request_body = Nokogiri::XML(SESSION_REQUEST_BODY)
-          request_body.at_css("username").content = username
-          request_body.at_css("password").content = password
-          return request_body.root.to_s
+        def make_session_retrieval_request
+
+          response = nil
+
+          @tokens.any? { |token|
+            response = make_request(URI.parse(@session_uri.to_s() + "/#{token}"))
+            response.code.to_i == 200 && !response.body.nil? && response.body != ''
+          }            
+
+          response
+          
         end
       end
     end

--- a/spec/omniauth/strategies/crowd_spec.rb
+++ b/spec/omniauth/strategies/crowd_spec.rb
@@ -19,7 +19,7 @@ describe OmniAuth::Strategies::Crowd, :type=>:strategy do
   @sso_url = nil
   @sso_url_image = nil
   let(:config) { OmniAuth::Strategies::Crowd::Configuration.new(strategy[1]) }
-  let(:validator) { OmniAuth::Strategies::Crowd::CrowdValidator.new(config, 'foo', 'bar') }
+  let(:validator) { OmniAuth::Strategies::Crowd::CrowdValidator.new(config, 'foo', 'bar', nil, nil) }
 
   describe 'Authentication Request Body' do
 

--- a/spec/omniauth/strategies/crowd_spec.rb
+++ b/spec/omniauth/strategies/crowd_spec.rb
@@ -9,10 +9,15 @@ describe OmniAuth::Strategies::Crowd, :type=>:strategy do
     [OmniAuth::Strategies::Crowd, {:crowd_server_url => @crowd_server_url,
                                     :application_name => @application_name,
                                     :application_password => @application_password,
-                                    :use_sessions => @using_sessions}]
+                                    :use_sessions => @using_sessions,
+                                    :sso_url => @sso_url,
+                                    :sso_url_image => @sso_url_image
+     }]
   end
 
   @using_sessions = false
+  @sso_url = nil
+  @sso_url_image = nil
   let(:config) { OmniAuth::Strategies::Crowd::Configuration.new(strategy[1]) }
   let(:validator) { OmniAuth::Strategies::Crowd::CrowdValidator.new(config, 'foo', 'bar') }
 
@@ -34,28 +39,6 @@ BODY
 </password>
 BODY
       expect(validator.send(:make_authentication_request_body, 'bar<')).to eq(body)
-    end
-  end
-
-  describe 'Session Request Body' do
-    it 'should send username and password in session request' do
-      body = <<-BODY.strip
-<authentication-context>
-  <username>foo</username>
-  <password>bar</password>
-</authentication-context>
-BODY
-      expect(validator.send(:make_session_request_body, 'foo', 'bar')).to eq(body)
-    end
-
-    it 'should escape special characters username and password in session request' do
-      body = <<-BODY.strip
-<authentication-context>
-  <username>foo</username>
-  <password>bar&lt;</password>
-</authentication-context>
-BODY
-      expect(validator.send(:make_session_request_body, 'foo', 'bar<')).to eq(body)
     end
   end
 
@@ -157,5 +140,248 @@ BODY
       expect(last_response).to be_redirect
       expect(last_response.headers['Location']).to match(/invalid_credentials/)
     end
+  end
+
+  describe 'GET /auth/crowd without credentials will redirect to login form' do
+    
+    sso_url = 'https://foo.bar'
+
+    before do
+      @using_sessions = true
+      @sso_url = sso_url
+    end
+
+    it 'should have the SSO button in the response body' do
+
+      found_legend = found_anchor = nil
+
+      get '/auth/crowd'
+
+      Nokogiri::HTML(last_response.body).xpath('//html/body/form/fieldset/*').each do |element|
+
+        if element.name === 'legend' && element.content() === 'SSO'
+          found_legend = true
+        elsif element.name === 'a' && element.attr('href') === "#{sso_url}/users/auth/crowd/callback"
+          found_anchor = true
+        end        
+      end
+
+      expect(found_legend).to(be(true))
+      expect(found_anchor).to(be(true))
+
+    end
+
+    after do
+      @using_sessions = false
+      @sso_url = nil
+    end
+
+  end
+  
+  describe 'GET /auth/crowd without credentials will redirect to login form which has custom image in the SSO link' do
+    
+    sso_url = 'https://foo.bar'
+    sso_url_image = 'https://foo.bar/image.png'
+    
+    before do
+      @using_sessions = true
+      @sso_url = sso_url
+      @sso_url_image = 'https://foo.bar/image.png'
+    end
+
+    it 'should have the SSO button with a custom image in the response body' do
+
+      found_legend = found_anchor = found_image = false
+
+      get '/auth/crowd'
+
+      Nokogiri::HTML(last_response.body).xpath('//html/body/form/fieldset/*').each do |element|
+
+        if element.name === 'legend' && element.content() === 'SSO'
+          found_legend = true
+        elsif element.name === 'a' && element.attr('href') === "#{sso_url}/users/auth/crowd/callback"
+
+          found_anchor = true
+
+          if element.children.length === 1 && element.children.first.name === 'img' && element.children.first.attr('src') === sso_url_image
+            found_image = true
+          end
+
+        end
+      end
+
+      expect(found_legend).to(be(true))
+      expect(found_anchor).to(be(true))
+      expect(found_image).to(be(true))
+
+    end
+
+    after do
+      @using_sessions = false
+      @sso_url = nil
+      @sso_url_image = nil
+    end
+
+  end
+
+  describe 'GET /auth/crowd without credentials but with SSO cookie will redirect to callback' do
+    
+    sso_url = 'https://foo.bar'
+    
+    before do
+      
+      @using_sessions = true
+      @sso_url = sso_url
+
+      set_cookie('crowd.token_key=foobar')
+
+    end
+
+    it 'should redirect to callback' do
+      get '/auth/crowd'
+      expect(last_response).to be_redirect
+      expect(last_response.headers['Location']).to eq('http://example.org/auth/crowd/callback')
+    end
+
+    after do
+
+      @using_sessions = false
+      @sso_url = nil
+
+      clear_cookies()
+
+    end
+
+  end
+  
+  describe 'POST /auth/crowd/callback without credentials but with SSO cookie will redirect to login form because session is invalid' do
+    
+    sso_url = 'https://foo.bar'
+    token = 'foobar'
+    
+    before do
+      
+      @using_sessions = true
+      @sso_url = sso_url
+
+      stub_request(:get, "https://bogus_app:bogus_app_password@crowd.example.org/rest/usermanagement/latest/session/#{token}").
+          to_return(:status => [404])
+
+      set_cookie("crowd.token_key=#{token}")
+
+    end
+
+    it 'should redirect to login form' do
+      post '/auth/crowd/callback'
+      expect(last_response).to be_redirect
+      expect(last_response.headers['Location']).to match(/invalid_credentials/)
+    end
+
+    after do
+
+      @using_sessions = false
+      @sso_url = nil
+
+      clear_cookies()
+
+    end
+
+  end
+  
+  describe 'GET /auth/crowd/callback without credentials but with SSO cookie will succeed' do
+
+    sso_url = 'https://foo.bar'
+    token = 'rtk8eMvqq00EiGn5iJCMZQ00'
+    
+    before do
+      
+      @using_sessions = true
+      @sso_url = sso_url
+
+      stub_request(:get, "https://bogus_app:bogus_app_password@crowd.example.org/rest/usermanagement/latest/session/#{token}").
+        to_return(:status => 200, :body => File.read(File.join(File.dirname(__FILE__), '..', '..', 'fixtures', 'session.xml')))
+      stub_request(:post, "https://bogus_app:bogus_app_password@crowd.example.org/rest/usermanagement/latest/session/#{token}").
+        to_return(:status => 200)
+      stub_request(:get, "https://bogus_app:bogus_app_password@crowd.example.org/rest/usermanagement/latest/user/group/direct?username=foo").
+        to_return(:body => File.read(File.join(File.dirname(__FILE__), '..', '..', 'fixtures', 'groups.xml')))
+      
+      set_cookie("crowd.token_key=#{token}")
+
+    end
+
+    it 'should return user data' do
+
+      auth = nil
+
+      get '/auth/crowd/callback'
+
+      auth = last_request.env['omniauth.auth']
+
+      expect(auth['provider']).to eq(:crowd)
+      expect(auth['uid']).to eq('foo')
+      expect(auth['info']).to be_kind_of(Hash)
+      expect(auth['info']['groups'].sort).to eq(["Developers", "jira-users"].sort)
+
+    end
+
+    after do
+
+      @using_sessions = false
+      @sso_url = nil
+
+      clear_cookies()
+
+    end
+
+  end
+
+  describe 'GET /auth/crowd/callback without credentials but with multiple SSO cookies will succeed because one of them is valid' do
+
+    sso_url = 'https://foo.bar'
+    
+    before do
+      
+      @using_sessions = true
+      @sso_url = sso_url
+
+      stub_request(:get, "https://bogus_app:bogus_app_password@crowd.example.org/rest/usermanagement/latest/session/foo").
+        to_return(:status => 404)
+      stub_request(:get, "https://bogus_app:bogus_app_password@crowd.example.org/rest/usermanagement/latest/session/fubar").
+        to_return(:status => 404)
+      stub_request(:get, "https://bogus_app:bogus_app_password@crowd.example.org/rest/usermanagement/latest/session/rtk8eMvqq00EiGn5iJCMZQ00").
+        to_return(:status => 200, :body => File.read(File.join(File.dirname(__FILE__), '..', '..', 'fixtures', 'session.xml')))
+      stub_request(:post, "https://bogus_app:bogus_app_password@crowd.example.org/rest/usermanagement/latest/session/rtk8eMvqq00EiGn5iJCMZQ00").
+        to_return(:status => 200)
+      stub_request(:get, "https://bogus_app:bogus_app_password@crowd.example.org/rest/usermanagement/latest/user/group/direct?username=foo").
+        to_return(:body => File.read(File.join(File.dirname(__FILE__), '..', '..', 'fixtures', 'groups.xml')))
+
+      header('Cookie', "crowd.token_key=foo;crowd.token_key=rtk8eMvqq00EiGn5iJCMZQ00;crowd.token_key=fubar")
+
+    end
+
+    it 'should return user data' do
+
+      auth = nil
+
+      get '/auth/crowd/callback'
+
+      auth = last_request.env['omniauth.auth']
+
+      expect(auth['provider']).to eq(:crowd)
+      expect(auth['uid']).to eq('foo')
+      expect(auth['info']).to be_kind_of(Hash)
+      expect(auth['info']['groups'].sort).to eq(["Developers", "jira-users"].sort)
+
+    end
+
+    after do
+
+      @using_sessions = false
+      @sso_url = nil
+
+      header('Cookie', nil)
+
+    end
+
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ Bundler.setup
 require 'rack/test'
 require 'webmock'
 require 'webmock/rspec'
+require 'nokogiri'
 
 require 'omniauth_crowd'
 RSpec.configure do |config|


### PR DESCRIPTION
Add the following features:
- Update existing Crowd session if session cookie is included in the request instead of credentials (Credentials override the cookie). This feature is bound to use_sessions parameters. Multiple cookies with the same name are supported (The correct one is found by validating against the Crowd API).
- The session cookie name can be changed with parameters session_cookie. Defaults to 'crowd.token_key'
- Sessions are now created (And validated on update) using the client IP address (Retrieved from X-Forwarded-For header or REMOTE_ADDRESS environment variable). This is needed at least for session validation if the session was created with a remote address validation factory.
- Add support for using external SSO page using parameters sso_url and sso_url_image. If sso_url is defined the login form will have a link to the SSO page. The link will be decorated with a image is sso_url_image is defined.

## NOTE
This commit breaks compatibility with older versions. The API itself doesn't break compability but the **use_sessions** parameter triggers new functionality.

~~Also, as keyword arguments are used the software depends on Ruby >= 2.0.0.~~