### PR TITLE
Remove use_sso? method from configuration

### DIFF
--- a/lib/omniauth/strategies/crowd.rb
+++ b/lib/omniauth/strategies/crowd.rb
@@ -19,7 +19,7 @@ module OmniAuth
       def request_phase
         if env['REQUEST_METHOD'] == 'GET'
 
-          if @configuration.use_sso? && request.cookies[@configuration.session_cookie]
+          if @configuration.use_sessions? && request.cookies[@configuration.session_cookie]
             redirect callback_url
           else            
             get_credentials
@@ -53,7 +53,7 @@ module OmniAuth
           text_field 'Login', 'username'
           password_field 'Password', 'password'
 
-          if configuration.use_sso? && configuration.sso_url
+          if configuration.use_sessions? && configuration.sso_url
             fieldset 'SSO' do
               html "<a href=\"#{configuration.sso_url}/users/auth/crowd/callback\">" + (configuration.sso_url_image ? "<img src=\"#{configuration.sso_url_image}\" />" : '') + "</a>"
             end
@@ -70,7 +70,7 @@ module OmniAuth
         password = creds.nil? ? nil : creds['password']
 
         unless creds
-          if @configuration.use_sso? && request.cookies[@configuration.session_cookie]
+          if @configuration.use_sessions? && request.cookies[@configuration.session_cookie]
             validator = CrowdValidator.new(@configuration, username, password, get_client_ip, get_sso_tokens)
           else
             return fail!(:no_credentials)

--- a/lib/omniauth/strategies/crowd/configuration.rb
+++ b/lib/omniauth/strategies/crowd/configuration.rb
@@ -51,10 +51,6 @@ module OmniAuth
           @user_group_url.nil? ? nil : append_username( @user_group_url, username)
         end
 
-        def use_sso?()
-          @use_sessions && @sso_url ? true : false
-        end
-
         private
         def parse_params(options)
           options= {:include_user_groups => true}.merge(options || {})


### PR DESCRIPTION
Remove OmniAuth::Strategies::Crowd::Configuration.use_sso? method. It's not needed because we already have use_sessions? and it was used incorrectly anyway (use_sso? checked for existence of sso_url and was used when the URL was not even needed).

This is a bug fix and probably a major level change since it's changes (Once again) how sessions are used. Sorry I didn't notice this earlier!